### PR TITLE
Fix array slicing indices on 3-dim transform

### DIFF
--- a/dasf/transforms/operations.py
+++ b/dasf/transforms/operations.py
@@ -30,7 +30,7 @@ class SliceArray:
         elif len(self.x) == 2:
             return X[0:self.x[0], 0:self.x[1]]
         elif len(self.x) == 3:
-            return X[0:self.x[0], 0:self.x[0], 0:self.x[0]]
+            return X[0:self.x[0], 0:self.x[1], 0:self.x[2]]
         else:
             raise Exception("The dimmension is not known")
 


### PR DESCRIPTION
x[0] was being used as the slicing index on all 3 dimensions when slicing a 3d array.