### PR TITLE
Changed poetry to poetry-core to enable editable installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,5 +73,5 @@ branch = true
 source = ["dasf"]
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.1.10"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This PR changes pyproject.toml file in order to enable editable installs. With presented changes, we can install dasf using `pip install -e .`.